### PR TITLE
updated getting started instructions and expose additional settings via menuconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Before compiling, you need to alter several settings in **menuconfig**:
         * Toggle if HomeKit app has video feed mirrored
     * Image sensor enhance settings
         * EXPERIMENTAL: adjusts contrast, saturation, etc for *better* image quality
+    * HomeKit Device Setup Code
+    * HomeKit Device Manufacturer
+    * HomeKit Device model name
+    * HomeKit Device model number
+    * HomeKit Device Serial number
+    * HomeKit Device Firmware version
+
+
     
 ## Add camera to HomeKit app
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,74 @@ Firmware for esp32-camera module to act as Apple Homekit IP camera.
 
 Based on [esp-homekit](https://github.com/maximkulkin/esp-homekit).
 
-## Configuration
+## Prerequisites
 
-Before compiling, you need to alter several settings in menuconfig (`make
-menuconfig`):
+* esp-idf
+    * Install esp-idf by following instructions on esp-idf project page (https://github.com/espressif/esp-idf#setting-up-esp-idf). 
+    * At the end you should have xtensa-esp32-elf toolchain in your path and IDF_PATH environment variable pointing to esp-idf directory.
+
+## Build instructions ESP32
+
+1. Clone git repo
+1. Change directory to repo `cd esp32-homekit-camera`
+1. Initialize and sync all submodules (recursively) `git submodule update --init --recursive`
+1. Configure device settings per **menuconfig settings** section, `make menuconfig`
+    * This step is critical
+1. Apply **esp32-camera.patch** patch `git apply --directory="components/esp32-camera" esp32-camera.patch`
+1. Compile code `make all`
+1. To prevent any effects from previous firmware (e.g. firmware crashing right at start), highly recommend to erase flash `make erase_flash`
+1. Upload Upload firmware to ESP32 `make flash monitor`
+    * Note, ESP32 **GPIO0** pin needs to be connected to **GND** pin to enable flashing
+
+## Menuconfig settings
+
+Before compiling, you need to alter several settings in **menuconfig**:
+* Serial flasher config
+    * Default serial port
+    * Flash size = **4 MB**
 * Partition Table
     * Partition Table = **Custom partition table CSV**
     * Custom partition CSV file = **partitions.csv**
 * Component config
+    * Driver configuration
+        * RTCIO configuration
+            * Support array `rtc_gpio_desc` for ESP32 = **check**
     * ESP32-specific
         * Support for external, SPI-connected RAM = **check**
         * SPI RAM config
-            * Initialize SPI RAM when booting the ESP32 = **check**
+            * Initialize SPI RAM during startup = **check**
             * SPI RAM access method = **Make RAM allocatable using malloc() as well**
     * Camera configuration
         * OV2640 Support = **check**
     * HomeKit
-        * SPI flash address for storing HomeKit data = 0x3A0000
+        * SPI flash address for storing HomeKit data = **0x3A0000**
 * ESP32 HomeKit Camera
-    * WiFi SSID and WiFi Password
-    * Camera Pins
+    * WiFi SSID
+    * WiFi Password
+    * Select Camera Pinout
         * Select Camera Pinout = *your variant of module*
+    * LED Pin
+        * PIN = *your variant of module*
+            * ESP32-CAM by AI-Thinker == **33**
+    
+## Add camera to HomeKit app
+
+1. Open Home app
+1. Click + sign to add accessory
+1. On Add Accessory screen, click `I Don't Have a Code or Cannot Scan` button
+1. The ESP camera accessory should be shown, click the icon
+1. On Uncertified Accessory prompt, select *Add Anyway*
+1. On Enter HomeKit Setup Code, enter setup code
+    * Default is `111-11-111`
+1. Click `Continue` button
+1. Select camera location, continue
+1. Enter camera name, continue
+1. Click Done
+1. Camera ready to use
+
+
+## Troubleshooting
+While not HomeKit specific, good amount of troubleshooting information for flashing ESP32 devices can be found at https://randomnerdtutorials.com/esp32-cam-troubleshooting-guide/
+
+## Other
+Device runs a webserver on HTTP port **5556**

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Based on [esp-homekit](https://github.com/maximkulkin/esp-homekit).
 1. To prevent any effects from previous firmware (e.g. firmware crashing right at start), highly recommend to erase flash `make erase_flash`
 1. Upload Upload firmware to ESP32 `make flash monitor`
     * Note, ESP32 **GPIO0** pin needs to be connected to **GND** pin to enable flashing
+    * To exit monitor, on mac *control+]*
 
 ## Menuconfig settings
 
@@ -53,6 +54,12 @@ Before compiling, you need to alter several settings in **menuconfig**:
     * LED Pin
         * PIN = *your variant of module*
             * ESP32-CAM by AI-Thinker == **33**
+    * Image sensor vertical flip
+        * Toggle if HomeKit app has video feed upside down
+    * Image sensor horizontal mirror
+        * Toggle if HomeKit app has video feed mirrored
+    * Image sensor enhance settings
+        * EXPERIMENTAL: adjusts contrast, saturation, etc for *better* image quality
     
 ## Add camera to HomeKit app
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -198,4 +198,26 @@ config LED_ACTIVE_LOW
 
 endchoice
 
+
+# Option to change vertical video orientation
+config ESP_SET_VFLIP
+    bool "Image sensor vertical flip"
+    default n
+    help
+        Enable image vertical flip
+
+# Option to change horizontal mirror video orientation
+config ESP_SET_HMIRROR
+    bool "Image sensor horizontal mirror"
+    default n
+    help
+        Enable image horizontal mirror
+
+# Option to enhance image
+config ESP_SET_ENHANCE_IMAGE
+    bool "Image sensor enhance settings"
+    default n
+    help
+        Enable image enhancement by adjusting settings such as contrast, saturation, etc
+
 endmenu

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -199,6 +199,44 @@ config LED_ACTIVE_LOW
 endchoice
 
 
+# HomeKit setup options
+config ESP_HOMEKIT_DEVICE_SETUP_CODE
+    string "HomeKit Device Setup Code"
+    default "111-11-111"
+    help
+    HomeKit Setup code for the example to use.
+
+config ESP_HOMEKIT_DEVICE_MANUFACTURER
+    string "HomeKit Device Manufacturer"
+    default "HaPK"
+    help
+    HomeKit manufacturer name the example to use.
+
+config ESP_HOMEKIT_DEVICE_MODEL_NAME
+    string "HomeKit Device model name"
+    default "ESP Camera"
+    help
+    HomeKit device model name the example to use.
+
+config ESP_HOMEKIT_DEVICE_MODEL_NUMBER
+    string "HomeKit Device model number"
+    default "1"
+    help
+    HomeKit device model number the example to use.
+
+config ESP_HOMEKIT_DEVICE_SERIAL_NUMBER
+    string "HomeKit Device Serial number"
+    default "1"
+    help
+    HomeKit serial number the example to use.
+
+config ESP_HOMEKIT_DEVICE_FIRMWARE_VERSION
+    string "HomeKit Device Firmware version"
+    default "0.1"
+    help
+    HomeKit firmware version number the example to use.
+
+
 # Option to change vertical video orientation
 config ESP_SET_VFLIP
     bool "Image sensor vertical flip"

--- a/main/accessory.c
+++ b/main/accessory.c
@@ -565,11 +565,11 @@ homekit_accessory_t *accessories[] = {
                       .services=(homekit_service_t*[])
     {
         HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics=(homekit_characteristic_t*[]){
-            HOMEKIT_CHARACTERISTIC(NAME, "Camera"),
-            HOMEKIT_CHARACTERISTIC(MANUFACTURER, "HaPK"),
-            HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, "1"),
-            HOMEKIT_CHARACTERISTIC(MODEL, "1"),
-            HOMEKIT_CHARACTERISTIC(FIRMWARE_REVISION, "0.1"),
+            HOMEKIT_CHARACTERISTIC(NAME, CONFIG_ESP_HOMEKIT_DEVICE_MODEL_NAME),
+            HOMEKIT_CHARACTERISTIC(MANUFACTURER, CONFIG_ESP_HOMEKIT_DEVICE_MANUFACTURER),
+            HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, CONFIG_ESP_HOMEKIT_DEVICE_SERIAL_NUMBER),
+            HOMEKIT_CHARACTERISTIC(MODEL, CONFIG_ESP_HOMEKIT_DEVICE_MODEL_NUMBER),
+            HOMEKIT_CHARACTERISTIC(FIRMWARE_REVISION, CONFIG_ESP_HOMEKIT_DEVICE_FIRMWARE_VERSION),
             HOMEKIT_CHARACTERISTIC(IDENTIFY, camera_identify),
             NULL
         }),
@@ -613,7 +613,7 @@ homekit_accessory_t *accessories[] = {
 
 homekit_server_config_t config = {
     .accessories = accessories,
-    .password = "111-11-111",
+    .password = CONFIG_ESP_HOMEKIT_DEVICE_SETUP_CODE,
     .on_event = camera_on_event,
     .on_resource = camera_on_resource,
 };

--- a/main/accessory.c
+++ b/main/accessory.c
@@ -678,6 +678,20 @@ void camera_accessory_init() {
         abort();
     }
 
+    // image sensor settings
+    sensor_t * s = esp_camera_sensor_get();
+    
+    #if CONFIG_ESP_SET_VFLIP
+        s->set_vflip(s, 1);
+    #endif
+    #if CONFIG_ESP_SET_HMIRROR
+        s->set_hmirror(s, 1);
+    #endif
+    #if CONFIG_ESP_SET_ENHANCE_IMAGE
+        s->set_saturation(s, -2);
+        s->set_contrast(s, 2);  
+    #endif
+
     tlv_values_t *video_codec_params = tlv_new();
     tlv_add_integer_value(video_codec_params, 1, 1, 1);  // Profile ID
     tlv_add_integer_value(video_codec_params, 2, 1, 0);  // Level


### PR DESCRIPTION
Three main themes:

* Improve getting started instructions. Resolves #57 and #58, makes note of #68  
* Feature: configurations of below settings via **menuconfig**
   * allow image rotation (vertical and horizontal) 
   * image enhancement (saturation and contrast)
* Enhancement: expose previously hardcoded HomeKit related settings into **menuconfig**
   * settings such as: setup code, manufacturer name, model name and number, serial number, and firmware version