### PR TITLE
Add menuconfig support for setting device hostname and device WIFI MAC address as serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Based on [esp-homekit](https://github.com/maximkulkin/esp-homekit).
 
 ## Menuconfig settings
 
-Before compiling, you need to alter several settings in **menuconfig**:
+Before compiling, you need to alter several settings in **menuconfig**, follow configuration prompts `make menuconfig`:
 * Serial flasher config
     * Default serial port
     * Flash size = **4 MB**
@@ -49,6 +49,7 @@ Before compiling, you need to alter several settings in **menuconfig**:
 * ESP32 HomeKit Camera
     * WiFi SSID
     * WiFi Password
+    * Device hostname
     * Select Camera Pinout
         * Select Camera Pinout = *your variant of module*
     * LED Pin
@@ -65,6 +66,8 @@ Before compiling, you need to alter several settings in **menuconfig**:
     * HomeKit Device model name
     * HomeKit Device model number
     * HomeKit Device Serial number
+    * Use WIFI MAC address as serial number
+        * Note: this takes precedence over static serial number setting above
     * HomeKit Device Firmware version
 
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -12,6 +12,12 @@ config ESP_WIFI_PASSWORD
     help
     WiFi password (WPA or WPA2) for the example to use.
 
+config ESP_HOSTNAME
+    string "Device hostname"
+    default "esp-cam"
+    help
+        Device hostname for the example to use.
+
 config XCLK_FREQ
     int "XCLK Frequency"
     default "20000000"
@@ -229,6 +235,12 @@ config ESP_HOMEKIT_DEVICE_SERIAL_NUMBER
     default "1"
     help
     HomeKit serial number the example to use.
+
+config ESP_HOMEKIT_DEVICE_SERIAL_NUMBER_MAC
+    bool "Use WIFI MAC address as serial number"
+    default n
+    help
+        HomeKit serial number the example to use. Takes precedence over static serial.
 
 config ESP_HOMEKIT_DEVICE_FIRMWARE_VERSION
     string "HomeKit Device Firmware version"

--- a/main/accessory.c
+++ b/main/accessory.c
@@ -24,7 +24,7 @@
 
 
 static ip4_addr_t ip_address;
-
+static char wifi_mac_address[32];
 
 void camera_accessory_set_ip_address(ip4_addr_t ip) {
     ip_address = ip;
@@ -567,7 +567,13 @@ homekit_accessory_t *accessories[] = {
         HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics=(homekit_characteristic_t*[]){
             HOMEKIT_CHARACTERISTIC(NAME, CONFIG_ESP_HOMEKIT_DEVICE_MODEL_NAME),
             HOMEKIT_CHARACTERISTIC(MANUFACTURER, CONFIG_ESP_HOMEKIT_DEVICE_MANUFACTURER),
-            HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, CONFIG_ESP_HOMEKIT_DEVICE_SERIAL_NUMBER),
+
+            #if CONFIG_ESP_HOMEKIT_DEVICE_SERIAL_NUMBER_MAC
+                HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, wifi_mac_address),
+            #else
+                HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, CONFIG_ESP_HOMEKIT_DEVICE_SERIAL_NUMBER),
+            #endif  
+
             HOMEKIT_CHARACTERISTIC(MODEL, CONFIG_ESP_HOMEKIT_DEVICE_MODEL_NUMBER),
             HOMEKIT_CHARACTERISTIC(FIRMWARE_REVISION, CONFIG_ESP_HOMEKIT_DEVICE_FIRMWARE_VERSION),
             HOMEKIT_CHARACTERISTIC(IDENTIFY, camera_identify),
@@ -630,6 +636,12 @@ void camera_accessory_init() {
 
     esp_log_level_set("*", ESP_LOG_INFO);
     esp_log_level_set("camera", ESP_LOG_VERBOSE);
+
+    // get WIFI MAC address & store it for later use
+    uint8_t mac[6] = {0};
+    esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    sprintf(wifi_mac_address, "%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    ESP_LOGI(TAG, "Device WIFI mac_address=\"%s\"", wifi_mac_address);
 
     /* IO13, IO14 is designed for JTAG by default,
      * to use it as generalized input,

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -47,6 +47,7 @@ static esp_err_t event_handler(void *ctx, system_event_t *event) {
 
 static void wifi_init() {
     tcpip_adapter_init();
+    ESP_ERROR_CHECK(tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, CONFIG_ESP_HOSTNAME));
     ESP_ERROR_CHECK(esp_event_loop_init(event_handler, NULL));
 
     wifi_init_config_t wifi_init_config = WIFI_INIT_CONFIG_DEFAULT();


### PR DESCRIPTION
Three enhancements:

* Allow *menuconfig* setting of device hostname vs original **espressif** (new default is **esp-cam**)
* Allow *menuconfig* support for setting device serial number to WIFI MAC address, still keeping recently added option for custom string
   * As inspired by idea mentioned in #14 
* Also one minor tweak to README.md to clarify how to interact with menuconfig, per comments in #60 

Sorry @maximkulkin i did not know on your plans on doing the earlier mentioned variable name refactoring, these will need adjustment also.




On side note, some of the wifi methods have been deprecated with IDF 4.x and will need to be updated to new example per https://github.com/espressif/esp-idf/blob/master/examples/wifi/getting_started/station/main/station_example_main.c, i've opened #71 to keep track.

```
esp_event_loop.h:2:2: warning: #warning "esp_event_loop.h is deprecated, please include esp_event.h instead" [-Wcpp]
app_main.c:49:5: warning: 'tcpip_adapter_init' is deprecated [-Wdeprecated-declarations]
app_main.c:51:5: warning: 'esp_event_loop_init' is deprecated [-Wdeprecated-declarations]
```